### PR TITLE
Add Channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
 
 script:
   - timeout 5 lua test/threads/spawn-child-and-die.lua
+  - timeout 5 lua test/channel/basic.lua
   - timeout 5 lua test/tcp/client-multi.lua
   - timeout 5 lua test/tcp/client-timeout.lua
   - timeout 5 lua test/udp/client-timeout.lua

--- a/cosock.lua
+++ b/cosock.lua
@@ -2,15 +2,15 @@ local cosocket = require "cosock.cosocket"
 local socket = require "socket"
 local channel = require "cosock.channel"
 
+local weaktable = { __mode = "kv" } -- mark table as having weak refs to keys and values
+local weakkeys = { __mode = "k" } -- mark table as having weak refs to keys
+
 local threads = {} --TODO: use set instead of list
-local newthreads = {} -- threads to be added before next iteration of run
-local threadnames = {}
+local threadnames = setmetatable({}, weakkeys)
 local threadswaitingfor = {} -- what each thread is waiting for
-local threadsocketmap = {} -- maps threads from which socket is being waiting
-local socketwrappermap = {} -- from native socket to async socket TODO: weak ref
-local threaderrorhandler = nil
-local threadtimeouts = {} -- map of thread => timeout info map
-local threadtimeoutlist = {} -- ordered list of timeout info maps
+local readythreads = {} -- like wakethreads, but for next loop (can be modified while looping wakethreads)
+local socketwrappermap = setmetatable({}, weaktable) -- from native socket to async socket
+local threaderrorhandler = nil -- TODO: allow setting error handler
 
 -- silence print statements in this file
 local print = function() end
@@ -20,11 +20,86 @@ local m = {}
 m.socket = cosocket
 m.channel = channel
 
+local timers = {}
+do
+  local timeouts = {}
+  local refs = {}
+  -- takes a relative timeout, a callback that is called with no params,
+  -- and an optional reference object for cancellation
+  timers.set = function(timeout, callback, ref)
+    print("timer set: %s,%s", timeout, ref)
+    local now = socket.gettime()
+    local timeoutat = timeout + now
+    print(timeoutat, timeout, now)
+    local timeoutinfo = {timeoutat = timeoutat, callback = callback, ref = ref}
+    table.insert(timeouts, timeoutinfo)
+    if ref then refs[ref] = timeoutinfo end
+  end
+
+  timers.cancel = function(ref)
+    local timeoutinfo = refs[ref]
+    if timeoutinfo then
+      -- mark as canceled, actual object will fall out at originally scheduled time
+      timeoutinfo.callback = nil
+      timeoutinfo.ref = nil
+    end
+    refs[ref] = nil
+  end
+
+  -- run expired timers, returns time to next timeout expiration
+  timers.run = function()
+    -- this seems exceptionally inefficient, but it works
+    -- TODO: I dunno, maybe use a timerwheel, after benchmarks
+    table.sort(
+      timeouts,
+      function(a,b)
+        -- bubble nil timeouts to the top to be dropped
+        return
+          not a.timeoutat or
+          (a.timeoutat and b.timeoutat and a.timeoutat < b.timeoutat)
+      end
+    )
+
+    local now = socket.gettime()
+
+    -- process timeout callback and remove
+    while timeouts[1] and (timeouts[1].timeoutat == nil or timeouts[1].timeoutat < now) do
+      local timeoutinfo = table.remove(timeouts, 1)
+      if timeoutinfo.callback then timeoutinfo.callback() end
+      if timeoutinfo.ref then refs[timeoutinfo.ref] = nil end
+    end
+
+    local timeoutat = (timeouts[1] or {}).timeoutat
+    print("timeout time", timeoutat)
+    if timeoutat then
+      local timeout = timeoutat - now
+      print("earliest timeout", timeout)
+      return timeout
+    else
+      return nil
+    end
+  end
+end
+
 function m.spawn(fn, name)
   local thread = coroutine.create(fn)
   print("cosocket spawn", name or thread)
   threadnames[thread] = name
-  table.insert(newthreads, thread)
+  threads[thread] = thread
+  readythreads[thread] = {}
+end
+
+local function wake_thread(wakelist, thread, kind, skt)
+  print("wake thread", thread, kind, skt)
+  wakelist[thread] = wakelist[thread] or {}
+  wakelist[thread][kind] = wakelist[thread][kind] or {}
+  table.insert(wakelist[thread][kind], skt)
+end
+
+local function wake_thread_err(wakelist, thread, err)
+  print("wake thread err", thread, err)
+  wakelist[thread] = wakelist[thread] or {}
+  wakelist[thread].err = err
 end
 
 -- Implementaion Notes:
@@ -39,111 +114,63 @@ end
 -- determines which has a timeout that has ellapsed.
 function m.run()
   local runstarttime = socket.gettime()
-  local recvr, sendr = {}, {} -- ready to send/recv sockets from luasocket.select
-  local nextwakethreads = nil -- set to table like wakethreads if a thread is woken by other thread
   while true do
-    print(string.format("================= %s ======================", socket.gettime() - runstarttime))
-    local deadthreads = {} -- list of threads that are finished executing
-    local wakethreads = nextwakethreads or {} -- map of thread => named resume params (rdy skts, timeout, etc)
-    nextwakethreads = nil
-    local sendt, recvt, timeout = {}, {}, nil -- cumulative values across all threads
+    print("================= %s ======================", socket.gettime() - runstarttime)
+    local wakethreads = {} -- map of thread => named resume params (rdy skts, timeout, etc)
+    local sendt, recvt, timeout = {}, {} -- cumulative values across all threads
 
-    -- threads can't be added while iterating through the main list
-    for _, thread in pairs(newthreads) do
-      threads[thread] = thread
-      wakethreads[thread] = {} -- empty no ready sockets or errors
-    end
-    newthreads = {}
+    -- add threads that have become ready since last loop to threads to be woken
+    for thread, reasons in pairs(readythreads) do
+      wakethreads[thread] = reasons
 
-    -- map recieve-ready sockets to threads to be woken & note which socket(s) were the cause
-    for _,lskt in ipairs(recvr) do
-      print("**** recvr ****")
-      local skt = socketwrappermap[lskt]
-      assert(skt)
-      local srcthreads = threadsocketmap[skt]
-      assert(srcthreads, "no thread waiting on socket")
-      assert(srcthreads.recv, "no thread waiting on recv ready")
-      wakethreads[srcthreads.recv] = wakethreads[srcthreads.recv] or {}
-      wakethreads[srcthreads.recv].recvr = wakethreads[srcthreads.recv].recvr or {}
-      table.insert(wakethreads[srcthreads.recv].recvr, skt)
-      local threadtimeoutinfo = threadtimeouts[srcthreads.recv]
-      if threadtimeoutinfo then threadtimeoutinfo.timeouttime = nil end -- mark timeout canceled
-    end
-
-    -- map send-ready sockets to threads to be woken & note which socket(s) were the cause
-    for _,lskt in ipairs(sendr) do
-      local skt = socketwrappermap[lskt]
-      print("**** sendr ****", skt)
-      assert(skt)
-      local srcthreads = threadsocketmap[skt]
-      for k,thread in pairs(srcthreads) do print(k,threadnames[thread] or thread) end
-      assert(srcthreads, "no thread waiting on socket")
-      assert(srcthreads.send, "no thread waiting on send ready")
-      wakethreads[srcthreads.send] = wakethreads[srcthreads.send] or {}
-      wakethreads[srcthreads.send].sendr = wakethreads[srcthreads.send].sendr or {}
-      table.insert(wakethreads[srcthreads.send].sendr, skt)
-      local threadtimeoutinfo = threadtimeouts[srcthreads.send]
-      if threadtimeoutinfo then threadtimeoutinfo.timeouttime = nil end -- mark timeout canceled
-    end
-
-    -- map hit timeouts to threads to be woken & note that timeout was the cause
-    local now = socket.gettime()
-    for _,toinfo in ipairs(threadtimeoutlist) do
-      if toinfo.timeouttime then -- skip canceled timeouts
-        if now < toinfo.timeouttime then break end -- only process expired timeouts
-        print(toinfo.timeouttime, now, toinfo.timeouttime - now)
-
-        wakethreads[toinfo.thread] = {err = "timeout" }
-        toinfo.timeouttime = nil -- mark timeout handled
-      end
+      -- drain copied table (note: the `readythreads` table must not be replaced with a new
+      -- table, callbacks hold a reference to this specific instance)
+      -- also this operation is actually valid, values can be modified or removed, just not added
+      readythreads[thread] = nil
     end
 
     -- run all threads
     for thread, params in pairs(wakethreads) do
-      print("+++++++++++++ waking", threadnames[thread] or thread, params.recvr, params.sendr, params.err)
+      print("waking", threadnames[thread] or thread, params.recvr, params.sendr, params.err)
       if coroutine.status(thread) == "suspended" then
+        -- cancel thread timeout (if any)
+        timers.cancel(thread)
+
+        -- cancel other timers
+        for kind, sockets in pairs(threadswaitingfor[thread] or {}) do
+          if kind ~= "timeout" then
+            for _, skt in pairs(sockets) do
+              assert(skt.setwaker, "non-wakeable socket")
+              print("unset waker", kind)
+              skt:setwaker(kind, nil)
+            end
+          end
+        end
+
+        -- resume thread
         local status, threadrecvt_or_err, threadsendt, threadtimeout =
           coroutine.resume(thread, params.recvr, params.sendr, params.err)
 
         if status and coroutine.status(thread) == "suspended" then
           local threadrecvt = threadrecvt_or_err
-          print("--------------- suspending", threadnames[thread] or thread, threadrecvt, threadsendt, threadtimeout)
+          print("suspending", threadnames[thread] or thread, threadrecvt, threadsendt, threadtimeout)
           -- note which sockets this thread is now waiting on
-          threadswaitingfor[thread] = {recvt = threadrecvt, sendt = threadsendt, timeout = threadtimeout}
+          threadswaitingfor[thread] = {recvr = threadrecvt, sendr = threadsendt, timeout = threadtimeout}
 
-	  if threadrecvt then
-            for _,skt in pairs(threadrecvt) do
-              -- waker-style virtual sockets only, luasocket sockets handled outside wakethread loop
-              if skt.setwaker then
-                skt:setwaker("recvr", function()
-                  nextwakethreads = nextwakethreads or {}
-                  nextwakethreads[thread] = nextwakethreads[thread] or {}
-                  nextwakethreads[thread].recvr = nextwakethreads[thread].recvr or {}
-                  table.insert(nextwakethreads[thread].recvr, skt)
-                end)
-              end
-            end
-	  end
-          if threadsendt then
-            for _,skt in pairs(threadsendt) do
-              -- waker-style virtual sockets only, luasocket sockets handled outside wakethread loop
-              if skt.setwaker then
-                skt:setwaker("sendr", function()
-                  nextwakethreads = nextwakethreads or {}
-                  nextwakethreads[thread] = nextwakethreads[thread] or {}
-                  nextwakethreads[thread].sendr = nextwakethreads[thread].sendr or {}
-                  table.insert(nextwakethreads[thread].sendr, skt)
-                end)
+          -- setup wakers for all sockets
+          for kind, sockets in pairs(threadswaitingfor[thread]) do
+            if kind ~= "timeout" then
+              for _, skt in pairs(sockets) do
+                assert(skt.setwaker, "non-wakeable socket")
+                print("set waker", kind)
+                skt:setwaker(kind, function() wake_thread(readythreads, thread, kind, skt) end)
               end
             end
           end
+
+          -- setup waker for timeout
           if threadtimeout then
-            local timeoutinfo = {
-              thread = thread,
-              timeouttime = threadtimeout + socket.gettime()
-            }
-            threadtimeouts[thread] = timeoutinfo
-            table.insert(threadtimeoutlist, timeoutinfo)
+            timers.set(threadtimeout, function() wake_thread_err(readythreads, thread, "timeout") end, thread)
           end
         elseif coroutine.status(thread) == "dead" then
           if not status and not threaderrorhandler then
@@ -156,30 +183,11 @@ function m.run()
             os.exit(-1)
           end
           print("dead", threadnames[thread] or thread, status, threadrecvt_or_err)
-          table.insert(deadthreads, thread)
+          threads[thread] = nil
+          threadswaitingfor[thread] = nil
         end
       else
-        print("warning: non-suspended thread encountered", coroutine.status(thread))
-      end
-    end
-
-    -- threads can't be removed while iterating through the main list
-    for _, thread in ipairs(deadthreads) do
-      threads[thread] = nil
-    end
-
-    -- cull dead timeouts
-    local listlen = #threadtimeoutlist -- list will shrink during iteration
-    for i = 1, #threadtimeoutlist do
-      local ri = listlen - i + 1
-      print("idx", i, ri, listlen)
-      print(threadtimeoutlist[ri])
-      if not threadtimeoutlist[ri] then
-        print(string.format("internal error: empty element in timeout list at %s/%s", ri, listlen))
-        table.remove(threadtimeoutlist, ri)
-      elseif not threadtimeoutlist[ri].timeouttime then
-        local toinfo = table.remove(threadtimeoutlist, ri)
-        threadtimeouts[toinfo.thread] = nil
+        print("non-suspended thread encountered", coroutine.status(thread))
       end
     end
 
@@ -189,25 +197,23 @@ function m.run()
       print("thread", threadnames[thread] or thread, coroutine.status(thread))
       if coroutine.status(thread) ~= "dead" then running = true end
     end
-    if not running and #newthreads == 0 then break end
+    if not running and not next(readythreads) then break end
 
     -- pull out threads' recieve-test & send-test sockets into each cumulative list
     for thread, params in pairs(threadswaitingfor) do
-      if params.recvt then
-        for _, skt in pairs(params.recvt) do
+      if params.recvr then
+        for _, skt in pairs(params.recvr) do
           if skt.inner_sock then
             print("thread for recvt:", threadnames[thread] or thread)
-            threadsocketmap[skt] = {recv = thread}
             table.insert(recvt, skt.inner_sock)
             socketwrappermap[skt.inner_sock] = skt;
           end
         end
       end
-      if params.sendt then
-        for _, skt in pairs(params.sendt) do
+      if params.sendr then
+        for _, skt in pairs(params.sendr) do
           if skt.inner_sock then
             print("thread for sendt:", threadnames[thread] or thread)
-            threadsocketmap[skt] = {send = thread}
             table.insert(sendt, skt.inner_sock)
             socketwrappermap[skt.inner_sock] = skt;
           end
@@ -215,48 +221,46 @@ function m.run()
       end
     end
 
-    if #newthreads > 0 then
-      print("new thread waiting, no timeout")
-      timeout = 0
-    elseif nextwakethreads then
+    -- run timeouts (will push to `readythreads`)
+    timeout = timers.run()
+
+    if next(readythreads) then
       print("thread woken during execution of other threads, no timeout")
       timeout = 0
-    else
-      -- this is exceptionally inefficient, but it works, TODO: I dunno, timerwheel, after benchmarks
-      table.sort(
-        threadtimeoutlist,
-        function(a,b) return a.timeouttime and b.timeouttime and a.timeouttime < b.timeouttime end
-      )
-      local timeouttime = (threadtimeoutlist[1] or {}).timeouttime
-      if timeouttime then
-        timeout = math.max(timeouttime - socket.gettime(), 0) -- negative timeouts mean infinity
-        print("earliest timeout", timeout)
-        now = socket.gettime()
-        for k,v in ipairs(threadtimeoutlist) do print(k,v,v.timeouttime - now) end
-      end
     end
 
-    --if not timeout and #recvt == 0 and #sendt == 0 then
-    --  -- in case of bugs
-    --  timeout = 1
-    --  print("WARNING: cosock tried to call socket select with no sockets and no timeout"
-    --    --[[ TODO: for when things actually work: .." this is a bug, please report it"]])
-    --end
+    if not timeout and #recvt == 0 and #sendt == 0 then
+      -- in case of bugs
+      error("cosock tried to call socket.select with no sockets and no timeout. "
+            .."this is a bug, please report it")
+    end
 
     print("start select", #recvt, #sendt, timeout)
     --for k,v in pairs(recvt) do print("r", k, v) end
     --for k,v in pairs(sendt) do print("s", k, v) end
-    local err
-    recvr, sendr, err = socket.select(recvt, sendt, timeout)
+    local recvr, sendr, err = socket.select(recvt, sendt, timeout)
     print("return select", #recvr, #sendr)
 
     if err and err ~= "timeout" then error(err) end
+
+    -- call waker on recieve-ready sockets
+    for _,lskt in ipairs(recvr) do
+      local skt = socketwrappermap[lskt]
+      assert(skt, "unknown socket")
+      assert(skt._wake, "unwakeable socket")
+      skt:_wake("recvr")
+    end
+
+    -- call waker on send-ready sockets
+    for _,lskt in ipairs(sendr) do
+      local skt = socketwrappermap[lskt]
+      assert(skt, "unknown socket")
+      assert(skt._wake, "unwakeable socket")
+      skt:_wake("sendr")
+    end
   end
 
   print("run exit")
-  --for k,v in ipairs(threadtimeoutlist) do print(k,v); print(threadnames[v.thread] or v.thread, v.timeouttime) end
-  assert(#threadtimeoutlist == 0, "thread timeoutlist")
-
 end
 
 return m

--- a/cosock/channel.lua
+++ b/cosock/channel.lua
@@ -1,0 +1,70 @@
+local m = {}
+
+-- TODO: move from channel.new() to channel() to match tcp/udp from socket
+function m.new()
+  local link = {
+    queue = {},
+    closed = false,
+    waker = nil
+  }
+  return
+    -- TODO: I'm unsure about closing on gc.
+    setmetatable({link = link}, { __index = m.sender--[[, __gc = m.sender.close]] }),
+    setmetatable({link = link}, { __index = m.receiver --[[, __gc = m.receiver.close]] })
+end
+
+m.receiver = {}
+
+function m.receiver:close()
+  self.link.closed = true
+end
+
+function m.receiver:receive()
+  while true do
+    if #self.link.queue > 0 then
+      local event = table.remove(self.link.queue, 1)
+      return event
+    elseif self.link.closed then
+      return nil, "closed"
+    else
+      coroutine.yield({self}, nil, self.timeout)
+      self.link.waker = nil
+    end
+  end
+end
+
+function m.receiver:settimeout(timeout)
+  self.timeout = timeout
+end
+
+-- TODO: should this be some kind of generic interface?
+function m.receiver:setwaker(kind, waker)
+  assert(kind == "recvr", "unsupported wake kind: "..tostring(kind))
+  assert(self.link.waker == nil or waker == nil,
+         "waker already set, receive can't be waited on from multiple places at once")
+  self.link.waker = waker
+end
+
+m.sender = {}
+
+function m.sender:close()
+  self.link.closed = true
+  if self.link.waker then
+    self.link.waker()
+  end
+end
+
+function m.sender:send(msg)
+  -- TODO: Allow setting an upper level on the queue size for backpressure
+  if not self.link.closed then
+    table.insert(self.link.queue, msg)
+    if self.link.waker then
+      self.link.waker()
+    end
+    return true
+  else
+    return false, "closed"
+  end
+end
+
+return m

--- a/cosock/cosocket/internals.lua
+++ b/cosock/cosocket/internals.lua
@@ -11,13 +11,25 @@ function m.passthroughbuilder(recvmethods, sendmethods)
         local status = ret[1]
         local err = ret[2]
         if err == "timeout" then
-          assert(recvmethods[method] or sendmethods[method],
-            "about to yield on method that is niether recv nor send")
-          local _, _, rterr = coroutine.yield(recvmethods[method] and {self} or {},
-                                              sendmethods[method] and {self} or {},
-                                              self.timeout)
+          local kind = recvmethods[method] and "recvr" or sendmethods[method] and "sendr"
+
+          assert(kind, "about to yield on method that is niether recv nor send")
+          local recvr, sendr, rterr = coroutine.yield(recvmethods[method] and {self} or {},
+                                                      sendmethods[method] and {self} or {},
+                                                      self.timeout)
+
+          -- woken, unset waker
+          self.wakers[kind] = nil
 
           if rterr then return nil --[[ TODO: value? ]], rterr end
+
+          if recvmethods[method] then
+            assert(recvr and #recvr == 1, "thread resumed without awaited socket or error (or too many sockets)")
+            assert(sendr == nil or #sendr == 0, "thread resumed with unexpected socket")
+          else
+            assert(recvr == nil or #recvr == 0, "thread resumed with unexpected socket")
+            assert(sendr and #sendr == 1, "thread resumed without awaited socket or error (or too many sockets)")
+          end
         elseif status then
           self.class = self.inner_sock.class
           if transform then

--- a/cosock/cosocket/tcp.lua
+++ b/cosock/cosocket/tcp.lua
@@ -19,7 +19,7 @@ setmetatable(m, {__call = function()
   local inner_sock, err = luasocket.tcp()
   if not inner_sock then return inner_sock, err end
   inner_sock:settimeout(0)
-  return setmetatable({inner_sock = inner_sock, class = "tcp{master}"}, { __index = m})
+  return setmetatable({inner_sock = inner_sock, wakers = {}, class = "tcp{master}"}, { __index = m})
 end})
 
 local passthrough = internals.passthroughbuilder(recvmethods, sendmethods)
@@ -27,7 +27,7 @@ local passthrough = internals.passthroughbuilder(recvmethods, sendmethods)
 m.accept = passthrough("accept", function(inner_sock)
   assert(inner_sock, "transform called on error from accept")
   inner_sock:settimeout(0)
-  return setmetatable({inner_sock = inner_sock, class = "tcp{client}"}, { __index = m})
+  return setmetatable({inner_sock = inner_sock, wakers = {}, class = "tcp{client}"}, { __index = m})
 end)
 
 m.bind = passthrough("bind")
@@ -70,6 +70,26 @@ function m:settimeout(timeout)
   self.timeout = timeout
 end
 
+function m:setwaker(kind, waker)
+  print("tcp set waker", self)
+  assert(kind == "recvr" or kind == "sendr", "unsupported wake kind: "..tostring(kind))
+  assert((not waker) or (not self.wakers[kind]),
+    tostring(kind).." waker already set, sockets can only block one thread per waker kind")
+  self.wakers[kind] = waker
+end
+
 m.shutdown = passthrough("shutdown")
+
+function m:_wake(kind, ...)
+  print("wake", self)
+  if self.wakers[kind] then
+    self.wakers[kind](...)
+    self.wakers[kind] = nil
+    return true
+  else
+    print("warning attempt to wake, but no waker set")
+    return false
+  end
+end
 
 return m

--- a/cosock/cosocket/udp.lua
+++ b/cosock/cosocket/udp.lua
@@ -17,7 +17,7 @@ setmetatable(m, {__call = function()
   local inner_sock, err = lsocket.udp()
   if not inner_sock then return inner_sock, err end
   inner_sock:settimeout(0)
-  return setmetatable({inner_sock = inner_sock, class = "udp{unconnected}"}, { __index = m})
+  return setmetatable({inner_sock = inner_sock, wakers = {}, class = "udp{unconnected}"}, { __index = m})
 end})
 
 local passthrough = internals.passthroughbuilder(recvmethods, sendmethods)
@@ -54,6 +54,25 @@ m.setsockname = passthrough("setsockname")
 
 function m:settimeout(timeout)
   self.timeout = timeout
+end
+
+function m:setwaker(kind, waker)
+  print("udp set waker", self)
+  assert(kind == "recvr" or kind == "sendr", "unsupported wake kind: "..tostring(kind))
+  assert((not waker) or (not self.wakers[kind]),
+    tostring(kind).." waker already set, sockets can only block one thread per waker kind")
+  self.wakers[kind] = waker
+end
+
+function m:_wake(kind, ...)
+  print("wake", self)
+  if self.wakers[kind] then
+    self.wakers[kind](...)
+    return true
+  else
+    print("warning attempt to wake, but no waker set", self)
+    return false
+  end
 end
 
 return m

--- a/test/channel/basic.lua
+++ b/test/channel/basic.lua
@@ -1,0 +1,61 @@
+local cosock = require "cosock"
+local channel = cosock.channel
+
+local senders_started = 0
+local senders_finished = 0
+local messages_sent = 0
+local messages_received = 0
+
+local function send10(sender, id, interval)
+  senders_started = senders_started + 1
+  cosock.spawn(function()
+    print("sender spawn", id)
+    for _=1,10 do
+      sender:send({from = id})
+      messages_sent = messages_sent + 1
+
+      cosock.socket.sleep(interval)
+    end
+    print("sender client exit")
+    senders_finished = senders_finished + 1
+
+    -- this is kinda gross, but I don't know if I have any other option than to manually track when
+    -- I'm done with this. Thanks garbage collection (which doesn't run while/before the loop gets
+    -- blocked in luasocket's select call).
+    if senders_finished == senders_started then sender:close() end
+  end, "sender "..tostring(id))
+end
+
+cosock.spawn(function()
+  print("receiver spawn")
+  local receiver
+  do
+    local sender
+    sender, receiver = channel.new()
+
+    send10(sender, 1, 0.001)
+    send10(sender, 2, 0.005)
+  end
+
+  --receiver:settimeout(0.0005)
+
+  while true do
+    local msg, err = receiver:receive()
+    if err == "closed" then break end
+    assert(msg or err, "receiver received no message nor error")
+    assert(not err, "receive error: "..tostring(err))
+    --assert(msg, "no message, but also no error")
+    if msg then messages_received = messages_received + 1 end
+  end
+
+  print("server exit")
+end, "receiver")
+
+cosock.run()
+
+assert(senders_started > 0, "no senders started")
+assert(senders_started == senders_finished, "not all senders finished")
+assert(messages_sent > 0, "no messages sent")
+assert(messages_sent == messages_received, "all messages not recieved: "..messages_sent..", "..messages_received)
+
+print("--------------- SUCCESS ----------------")

--- a/test/udp/client-timeout.lua
+++ b/test/udp/client-timeout.lua
@@ -21,7 +21,7 @@ local function fast_client(host, port)
 
     fast_client_finished = true
     print("fast client exit")
-  end, "single client")
+  end, "fast (0.01) client")
 
 end
 
@@ -41,7 +41,7 @@ local function slow_client(host, port)
 
     slow_client_finished = true
     print("slow client exit")
-  end, "single client")
+  end, "slow (0.3) client")
 end
 
 cosock.spawn(function()
@@ -63,7 +63,7 @@ cosock.spawn(function()
   end
 
   print("server exit")
-end)
+end, "server")
 
 
 


### PR DESCRIPTION
This adds an inter-thread communication path that has a socket-ish API, but that does not rely on OS-level sockets.

This currently implements an unbounded, unidirectional, multiple-sender, single-consumer queue that we'll call a "channel". There's definitely room for improvement, foremost bounding the queue size so that we're able to pass backpressure through a channel, but this is a good start for building basic things.

Also, as part of implementing channels this introduces a "waker" system that should allow further extension of cosock from outside the core library. It then, as a separate commit, reimplements thread-socket readiness on top of the new waker system, pulling timeouts out into a logically separate system in the process.