### PR TITLE
prevent double wakes

### DIFF
--- a/cosock.lua
+++ b/cosock.lua
@@ -163,7 +163,11 @@ function m.run()
               for _, skt in pairs(sockets) do
                 assert(skt.setwaker, "non-wakeable socket")
                 print("set waker", kind)
-                skt:setwaker(kind, function() wake_thread(readythreads, thread, kind, skt) end)
+                skt:setwaker(kind, function()
+                  -- unset waker so we can't double wake
+                  skt:setwaker(kind, nil)
+                  wake_thread(readythreads, thread, kind, skt)
+                end)
               end
             end
           end


### PR DESCRIPTION
The channel wake PR revealed a bug in cosock's wake logic. Because sockets
are tracked in a list for a given wake kind for each thread in `readythreads`
it's possible to have the same socket listed twice. This wasn't a problem
before the the change to wake channels becuase we only ever woke from a
single place. Now though we will wake a channel both when a send is
performed and when a thread blocks on a channel that is currently holding
messages. This means when we send to a channel that is also blocked on by
another thread in the same cosock loop, but where the sending thread is
processed before the blocking thread, we will get the socket twice in our
wake reason list for the blocking thread even though there is only one
message.

This change removes the current waker on any call to wake so that any
further attempts to wake will not find a waker function, limiting us to
a single wake reason for a given socket.

Unfortuantley this is impossible to reliably test since threads are
processed in a non-deterministic order, so this PR doesn't have any tests.