### PR TITLE
asyncify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   - luarocks install luasec
 
 script:
+  - timeout 5 lua test/error-handling/try-protect.lua
   - timeout 5 lua test/threads/spawn-child-and-die.lua
   - timeout 5 lua test/channel/basic.lua
   - timeout 5 lua test/channel/via-select.lua

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,6 @@ script:
   - timeout 5 lua test/udp/client-timeout.lua
   - timeout 5 lua test/ssl/client-multi.lua
   - timeout 5 lua test/ssl/client-timeout.lua
+    # travis blocks outgoing network traffic, disable, but leave it here to show it's intentional
+    #- timeout 5 lua test/http/single-client.lua
   - luacheck .

--- a/cosock/socket/internals.lua
+++ b/cosock/socket/internals.lua
@@ -44,7 +44,8 @@ function m.passthroughbuilder(recvmethods, sendmethods)
             return unpack(ret)
           end
         else
-          return unpack(ret)
+          -- for reasons I can't figure out `unpack(ret)` returns nothing when nil precedes other values
+          return ret[1], ret[2], ret[3], ret[4], ret[5]
         end
       until nil
     end

--- a/cosock/socket/tcp.lua
+++ b/cosock/socket/tcp.lua
@@ -68,6 +68,8 @@ m.setstats = passthrough("setstats")
 
 function m:settimeout(timeout)
   self.timeout = timeout
+
+  return 1.0
 end
 
 internals.setuprealsocketwaker(m)

--- a/cosock/socket/udp.lua
+++ b/cosock/socket/udp.lua
@@ -54,6 +54,8 @@ m.setsockname = passthrough("setsockname")
 
 function m:settimeout(timeout)
   self.timeout = timeout
+
+  return 1.0
 end
 
 internals.setuprealsocketwaker(m)

--- a/test/error-handling/try-protect.lua
+++ b/test/error-handling/try-protect.lua
@@ -1,0 +1,86 @@
+local cosock = require "cosock"
+local socket = cosock.socket
+
+local funcsran = 0
+local finalizersran = 0
+
+------------------
+-- mock functions
+------------------
+
+local function happy()
+  funcsran = funcsran + 1
+  if 1+1 == 2 then
+    return "all good"
+  else
+    return nil,  "your computer is super broke"
+  end
+end
+
+local function callserror()
+  funcsran = funcsran + 1
+  error("I meant to do that")
+end
+
+local function returnserror()
+  funcsran = funcsran + 1
+  return nil, "is this really my purpose in life?"
+end
+
+---------------------------------------------
+-- try each mock function with default `try`
+---------------------------------------------
+
+local pth = socket.protect(function()
+  return socket.try(happy())
+end)
+
+assert(pth() == "all good", "not all good")
+
+local ptce = socket.protect(function()
+  socket.try(callserror())
+end)
+
+assert(not pcall(ptce), "internal error didn't error")
+
+local ptre = socket.protect(function()
+  socket.try(returnserror())
+end)
+
+ptre()
+
+---------------------------------------------------
+-- try each mock function with custom try function
+---------------------------------------------------
+
+local custtry = socket.newtry(function()
+  finalizersran = finalizersran + 1
+end)
+
+local pcth = socket.protect(function()
+  return custtry(happy())
+end)
+
+assert(pcth() == "all good", "not all good")
+
+local pctce = socket.protect(function()
+  custtry(callserror())
+end)
+
+assert(not pcall(pctce), "internal error didn't error")
+
+local pctre = socket.protect(function()
+  custtry(returnserror())
+end)
+
+pctre()
+
+---------------------------------
+-- check that stuff actually ran
+---------------------------------
+
+assert(funcsran == 6, "functions didn't run")
+assert(finalizersran == 1, "finalizers didn't run")
+
+print("--------------- SUCCESS ----------------")
+

--- a/test/http/single-client.lua
+++ b/test/http/single-client.lua
@@ -1,0 +1,51 @@
+local cosock = require "cosock"
+local socket = require "cosock.socket"
+local http = cosock.asyncify "socket.http"
+
+print("start")
+
+local requests_started = {}
+local requests_finished = {}
+
+local function slow_request(id)
+  return function()
+    print("id", id)
+    requests_started[id] = true
+
+    local starttime = socket.gettime()
+    local body, status = http.request("http://httpbin.org/delay/3")
+    local endtime = socket.gettime()
+
+    print(string.format("request took %s seconds", endtime - starttime))
+
+    print("body", body)
+    print("status", status)
+    assert(status == 200, "request failed")
+
+    requests_finished[id] = true
+
+    return endtime - starttime
+  end
+end
+
+-- check that after 1 second that 3 requests have started, but that 0 have finished
+cosock.spawn(function()
+  socket.select(nil, nil, 1)
+
+  print("requests started", #requests_started)
+  assert(#requests_started == 3, "not all requests (or too many) started")
+  print("requests finished", #requests_finished)
+  assert(#requests_finished == 0, "some requests already finished")
+end,
+"checker")
+
+cosock.spawn(slow_request(1), "slow1")
+cosock.spawn(slow_request(2), "slow2")
+cosock.spawn(slow_request(3), "slow3")
+
+cosock.run()
+
+print("requests finished", #requests_finished)
+assert(#requests_finished == 3, "not all requests (or too many) finished")
+
+print("--------------- SUCCESS ----------------")


### PR DESCRIPTION
This adds the `asyncify` method. It works just like `require` except it causes calls to `require "socket"` in whatever is (recursively) `require`d to return the `cosock.socket` module. It does this by re-implementing the top layer of `require`, manually calling each searcher in `package.searchers` and once one of the searchers returns a loader it'll patch that loader's environment replacing `require` with our `wrappedrequire` that simply checks if the module being required is "socket", changing it to `cosock.socket` if it is, and passing the call through to the real `require` function.

All ^ is in the first commit. The rest are bug fixes for problems discovered while writing the test for all of this in the last commit. That test `asyncify`s luasocket's http module as a torture test.