### PR TITLE
Asyncify Recursively

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,5 @@ jobs:
         run: timeout 5 lua test/http/https-via-ssl.lua
       - name: http https via http
         run: timeout 5 lua test/http/https-via-http.lua
+      - name: asyncify-works
+        run: timeout 5 lua test/asyncify/asyncify-works.lua

--- a/cosock.lua
+++ b/cosock.lua
@@ -59,6 +59,8 @@ local print = function() end
 
 local m = {}
 
+m._VERSION = "0.2.0"
+socket._COSOCK_VERSION = m._VERSION
 m.socket = socket
 m.channel = channel
 m.ssl = ssl

--- a/cosock.lua
+++ b/cosock.lua
@@ -60,7 +60,6 @@ local print = function() end
 local m = {}
 
 m._VERSION = "0.2.0"
-socket._COSOCK_VERSION = m._VERSION
 m.socket = socket
 m.channel = channel
 m.ssl = ssl
@@ -129,24 +128,20 @@ end
 -- asyncify
 do
   local realrequire = require
+  local asyncify_loaded = {}
   local function wrappedrequire(name)
     --[[ Our API is incomplete, just choose a few specific modules for now
     if string.sub(name, 1, 6) == "socket" then
       name = "cosock."..name
     end
     ]]
-
+    local subbed
     if name == "socket" then
-      name = "cosock.socket"
-    elseif name == "socket.http" then
-      name = "cosock.socket.http"
-    elseif name == "ssl.https" then
-      name = "cosock.ssl.https"
+      subbed = "cosock.socket"
     elseif name == "ssl" then
-      name = "cosock.ssl"
+      subbed = "cosock.ssl"
     end
-
-    return realrequire(name)
+    return subbed and realrequire(subbed) or m.asyncify(name)
   end
 
   local fakeenv = {
@@ -156,6 +151,12 @@ do
 
   function m.asyncify(name)
     local err
+    if name == "socket" then name = "cosock.socket" end
+    if name == "ssl" then name = "cosock.ssl" end
+    
+    if asyncify_loaded[name] then
+      return asyncify_loaded[name]
+    end
     for _,searcher in ipairs(package.searchers) do
       local loader, loc = searcher(name)
       if type(loader) == "function" then
@@ -174,8 +175,13 @@ do
 
         -- load module with loader
         local module = loader(name, loc)
-
+        asyncify_loaded[name] = module
         return module
+      -- If the last searcher returns nil we need to check the
+      -- package.loaded or we may miss some std lib packages
+      elseif loader == nil and package.loaded[name] then
+        asyncify_loaded[name] = package.loaded[name]
+        return package.loaded[name]
       else
         -- non-function values mean error, keep last non-nil value
         err = loader or err

--- a/cosock/socket.lua
+++ b/cosock/socket.lua
@@ -11,10 +11,9 @@ local udp = assert(require "cosock.socket.udp")
 --- (It's not 100% there yet.)
 local m = {}
 
--- extraced from luasocket 3.0-rc1
-m._VERSION = "socket 3.0-rc1"
-m._SETSIZE = 1024
-m.BLOCKSIZE = 2048
+m._VERSION = luasocket._VERSION
+m._SETSIZE = luasocket._SETSIZE
+m.BLOCKSIZE = luasocket.BLOCKSIZE
 
 m.bind = function(host, port, backlog)
   local ret

--- a/test/asyncify/asyncify-works.lua
+++ b/test/asyncify/asyncify-works.lua
@@ -1,0 +1,46 @@
+-- disable this test for 5.1 since we can't asyncify
+if _VERSION == "Lua 5.1" then os.exit(0) end
+local cosock = require "cosock"
+-- import the sync versions of one and two for comparison later
+local sync_zero = require("socket")
+local sync_one = require("test.asyncify.one")
+local sync_two = require("test.asyncify.two")
+
+function test_module(async, sync, name)
+    print(string.format("Trying %s", name))
+    -- Assert we didn't get an error string from cosock.asyncify
+    assert(type(async) ~= "string", "Expected table found string for %s: %s", name, tostring(two))
+    -- Assert we didn't get the luasocket module
+    assert(async ~= sync, "require produced the same result as asyncify for", name)
+    -- Confirm that the async module is expecting to run via cosock
+    local selected, err = pcall(async.select, {}, {}, 0.1)
+    assert(not selected, "selected async w/o error for", name)
+    assert(type(err) == "string", "No error for", name)
+    assert(err:match("attempt to yield from outside a coroutine"),
+        string.format("bad async error for %s: %s", name, err))
+    -- Confirm the sync module will timeout on select
+    local sync_r, sync_w, sync_err = sync_zero.select({}, {}, 0.1)
+    assert(#sync_r == 0, "selected sync read for", name)
+    assert(#sync_w == 0, "selected sync write for", name)
+    assert(sync_err == "timeout", "bad sync erorr for", name)
+end
+
+-- Test wrapping via asyncify
+local zero = cosock.asyncify "socket"
+test_module(zero, sync_zero, "direct")
+
+-- test wrapping when first module requires socket
+local one = cosock.asyncify "test.asyncify.one"
+test_module(one, sync_one, "non-nested")
+
+-- test wrapping when first module requires a module that
+-- requires socket
+local two = cosock.asyncify "test.asyncify.two"
+test_module(two, sync_two, "nested")
+
+-- Ensure the "standard library" module names work via asynify
+local t = require "table"
+local at = cosock.asyncify("table")
+assert(at == t, string.format("%s", at))
+local nat = cosock.asyncify("test.asyncify.nested.table")
+assert(nat == t, string.format("%s", nat))

--- a/test/asyncify/nested/module.lua
+++ b/test/asyncify/nested/module.lua
@@ -1,0 +1,1 @@
+return require "socket"

--- a/test/asyncify/nested/table.lua
+++ b/test/asyncify/nested/table.lua
@@ -1,0 +1,1 @@
+return require("table")

--- a/test/asyncify/one.lua
+++ b/test/asyncify/one.lua
@@ -1,0 +1,1 @@
+return require("socket")

--- a/test/asyncify/two.lua
+++ b/test/asyncify/two.lua
@@ -1,0 +1,1 @@
+return require "test.asyncify.nested.module"


### PR DESCRIPTION
As illustrated in the new asyncify test, we are not currently recursively swapping socket for cosock.socket. Only the top level module is getting swapped.