### PR TITLE
Fix/receive prefix

### DIFF
--- a/cosock/socket/internals.lua
+++ b/cosock/socket/internals.lua
@@ -66,7 +66,11 @@ function m.passthroughbuilder(recvmethods, sendmethods)
           end
         else
           -- for reasons I can't figure out `unpack(ret)` returns nothing when nil precedes other values
-          return ret[1], ret[2], ret[3], ret[4], ret[5]
+          if transform.output then
+            return transform.output(ret[1], ret[2], ret[3], ret[4], ret[5])
+          else
+            return ret[1], ret[2], ret[3], ret[4], ret[5]
+          end
         end
       until nil
     end

--- a/cosock/socket/tcp.lua
+++ b/cosock/socket/tcp.lua
@@ -78,18 +78,18 @@ m.receive = passthrough("receive", function()
       -- save these for later
       pattern = ipattern
       if type(pattern) == "number" then bytes_remaining = pattern end
-      prefix = iprefix
+      new_part(iprefix)
 
-      return pattern, prefix
+      return pattern
     end,
     -- receives results of luasocket call when we need to block, provides parameters to pass when next ready
     blocked = function(_, _, partial)
       new_part(partial)
       if bytes_remaining then
         assert(bytes_remaining > 0, "somehow about to block despite being done")
-        return bytes_remaining, prefix
+        return bytes_remaining
       else
-        return pattern, prefix
+        return pattern
       end
     end,
     -- transform output after final success or (non-block) error

--- a/test/tcp/prefix.lua
+++ b/test/tcp/prefix.lua
@@ -1,0 +1,54 @@
+print("----------------------------------------")
+local cosock = require "cosock"
+assert(cosock, "require something")
+assert(type(cosock) == "table", "cosock is table")
+local socket = require "cosock.socket"
+
+local function run_test(port, send_new_line, tx)
+    local server = socket.tcp()
+    server:bind("*", port)
+    server:setoption("reuseaddr", true)
+    server:listen(1)
+    local addr = server:getsockname()
+    cosock.spawn(function()
+        local client = socket.tcp()
+        client:settimeout(0.3)
+        client:connect(addr, port)
+        print("connected to", port)
+        local result = table.pack(client:receive("*l", "prefix"))
+        tx:send(result)
+    end, "client-task" .. tostring(port))
+    
+    local client = server:accept()
+    for i=1,4 do
+        client:send("chunk" .. tostring(i))
+        socket.sleep(0.1)
+    end
+    if send_new_line then
+        client:send("\n")
+    end
+    client:close()
+    
+end
+
+math.randomseed(socket.gettime())
+local port = math.random(3000, 9000)
+
+cosock.spawn(function()
+    local tx, rx = cosock.channel.new()
+    run_test(port, true, tx)
+    local output = assert(table.unpack(rx:receive()))
+    assert(output == "prefixchunk1chunk2chunk3chunk4", "Invalid outout: " .. tostring(output));
+end, "send new line")
+
+cosock.spawn(function()
+    local tx, rx = cosock.channel.new()
+    run_test(port+1, false, tx)
+    local output = assert(rx:receive())
+    assert(output[3], output[2])
+    assert(output[3]:match("prefixchunk1chunk2chunk3"), string.format("Invalid outout: %s", output));
+end, "don't send new line")
+
+cosock.run()
+
+print("--------------- SUCCESS ----------------")


### PR DESCRIPTION
As described in #26 the behavior of our tcp receive was causing multiple prefixes to be appended to the output when the server sends small chunks. 

In the process of fixing this I also encountered the fact that `transform.output` is not being applied when we have a non-yielding error message. This results in a loss of information, specifically for tcp receive. I validated that the luasocket behavior for partials on an error is to return the partial with a single prefix as the 3rd return value