### PR TITLE
chore: remove unused prefix variable from passthrough receive

### DIFF
--- a/cosock/socket/tcp.lua
+++ b/cosock/socket/tcp.lua
@@ -59,7 +59,7 @@ m.getstats = passthrough("getstats")
 m.listen = passthrough("listen")
 
 m.receive = passthrough("receive", function()
-  local pattern, prefix
+  local pattern
   -- save partial resuts on timeout
   local parts = {}
   local bytes_remaining


### PR DESCRIPTION
missed in #26 