### PR TITLE
check the return value of  to timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,8 @@ jobs:
         run: timeout 5 lua test/channel/basic.lua
       - name: select channel
         run: timeout 5 lua test/channel/via-select.lua
+      - name: channel timeout
+        run: timeout 5 lua test/channel/recv-timesout.lua
       - name: tcp client-multi
         run: timeout 5 lua test/tcp/client-multi.lua
       - name: tcp client-timeout

--- a/cosock/channel.lua
+++ b/cosock/channel.lua
@@ -27,7 +27,10 @@ function m.receiver:receive()
     elseif self.link.closed then
       return nil, "closed"
     else
-      coroutine.yield({self}, nil, self.timeout)
+      local _, _, err = coroutine.yield({self}, nil, self.timeout)
+      if err then
+        return nil, err
+      end
       self.link.waker = nil
     end
   end

--- a/test/channel/recv-timesout.lua
+++ b/test/channel/recv-timesout.lua
@@ -1,0 +1,12 @@
+local cosock = require "cosock"
+
+cosock.spawn(function()
+  local _, rx = cosock.channel.new()
+  rx:settimeout(0.5)
+  local msg, err = rx:receive()
+  assert(msg == nil, "Expected no message on receieve, got " .. tostring(msg))
+  assert(err == "timeout", "expected err on receive to be `timeout` found " .. tostring(msg))
+end)
+
+cosock.run()
+print("--------------- SUCCESS ----------------")


### PR DESCRIPTION
I noticed that we use the `self.timeout` property in `coroutine.yield` but we don't check to see if the return there has an error, we just assume that it will be `{self}, nil, nil`.