### PR TITLE
fix: Propagate accept errors on tcp sockets

### DIFF
--- a/cosock/socket/tcp.lua
+++ b/cosock/socket/tcp.lua
@@ -25,10 +25,12 @@ end})
 local passthrough = internals.passthroughbuilder(recvmethods, sendmethods)
 
 m.accept = passthrough("accept", {
-  output = function(inner_sock)
-    assert(inner_sock, "transform called on error from accept")
+  output = function(inner_sock, err)
+    if not inner_sock or err ~= nil then
+      return nil, err
+    end
     inner_sock:settimeout(0)
-    return setmetatable({inner_sock = inner_sock, class = "tcp{client}"}, { __index = m})
+    return setmetatable({ inner_sock = inner_sock, class = "tcp{client}" }, { __index = m })
   end
 })
 


### PR DESCRIPTION
The existing passthrough builder `assert`s that the return value of the wrapped accept call succeeds. This doesn't work if, for example, a timeout is set on the server socket, as the timeout comes across as an error condition.

We revise the passthrough's output transformer to propagate errors instead of asserting while preserving the original transformation logic in the success case.