### PR TITLE
Add more debug information

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,10 +56,10 @@ jobs:
       - name: ssl client-timeout
         run: timeout 5 lua test/ssl/client-timeout.lua
       - name: http http
-        run: timeout 5 lua test/http/http.lua
+        run: timeout 30 lua test/http/http.lua
       - name: http https via ssl
-        run: timeout 5 lua test/http/https-via-ssl.lua
+        run: timeout 30 lua test/http/https-via-ssl.lua
       - name: http https via http
-        run: timeout 5 lua test/http/https-via-http.lua
+        run: timeout 30 lua test/http/https-via-http.lua
       - name: asyncify-works
         run: timeout 5 lua test/asyncify/asyncify-works.lua

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,3 +63,7 @@ jobs:
         run: timeout 30 lua test/http/https-via-http.lua
       - name: asyncify-works
         run: timeout 5 lua test/asyncify/asyncify-works.lua
+      - name: thread-metadata sleeping
+        run: timeout 5 lua test/thread-metadata/sleeping.lua
+      - name: thread-metadata sockets
+        run: timeout 5 lua test/thread-metadata/sockets.lua

--- a/cosock.lua
+++ b/cosock.lua
@@ -213,7 +213,6 @@ function m.spawn(fn, name)
   print("socket spawn", name or thread)
   threadnames[thread] = name
   threads[thread] = thread
-  last_wakes[thread] = os.time()
   readythreads[thread] = {}
 end
 
@@ -221,7 +220,6 @@ local function wake_thread(wakelist, thread, kind, skt)
   print("wake thread", thread, kind, skt)
   wakelist[thread] = wakelist[thread] or {}
   wakelist[thread][kind] = wakelist[thread][kind] or {}
-  last_wakes[thread] = os.time()
   table.insert(wakelist[thread][kind], skt)
 end
 
@@ -229,7 +227,6 @@ local function wake_thread_err(wakelist, thread, err)
   print("wake thread err", thread, err)
   wakelist[thread] = wakelist[thread] or {}
   wakelist[thread].err = err
-  last_wakes[thread] = os.time()
 end
 
 -- Implementaion Notes:
@@ -276,7 +273,7 @@ function m.run()
             end
           end
         end
-
+        last_wakes[thread] = os.time()
         -- resume thread
         local status, threadrecvt_or_err, threadsendt, threadtimeout =
           coroutine.resume(thread, params.recvr, params.sendr, params.err)

--- a/test/thread-metadata/sleeping.lua
+++ b/test/thread-metadata/sleeping.lua
@@ -1,0 +1,73 @@
+local cosock = require "cosock"
+local named = "some-name"
+local capture = "capture-thread"
+cosock.spawn(function()
+  cosock.socket.sleep(1)
+  cosock.socket.sleep(1)
+  cosock.socket.sleep(1)
+end, named)
+
+cosock.spawn(function()
+  cosock.socket.sleep(2)
+  cosock.socket.sleep(1)
+end)
+local thread_info
+cosock.spawn(function()
+  cosock.socket.sleep(2.1)
+  thread_info = cosock.get_thread_metadata()
+end, capture)
+cosock.run()
+local completed = os.time()
+local threads = {}
+assert(thread_info, "thread_info was nil")
+assert(#thread_info == 3, string.format("Thread info was not 3: %s", #thread_info))
+
+for _, info in pairs(thread_info) do
+  local age = os.difftime(completed, info.last_wake)
+  assert(threads[info.name or "anon"] == nil, "about to clobber " .. (info.name or "anon"))
+  threads[info.name or "anon"] = {
+    data = info,
+    age = age,
+  }
+end
+
+local function assert_thread_info(
+  dets,
+  expectations,
+  name
+)
+  local assert_prefix = string.format("Error from s", name)
+  assert(
+    dets.data.name == expectations.name,
+    string.format(
+      "%s expected name to be %s, found %q",
+      assert_prefix,
+      expectations.name or "nil",
+      dets.data.name or "nil"
+    )
+  )
+
+  assert(dets.age < 3, string.format("%s found too old thread %s", assert_prefix, dets.age))
+  assert(
+    dets.data.name == expectations.name,
+    string.format(
+      "%s expected status to be %s, found %q",
+      assert_prefix,
+      expectations.status or "nil",
+      dets.data.status or "nil"
+    )
+  )
+end
+
+assert_thread_info(threads.anon,
+  {status = "suspended", recvt = 0, sendt = 0},
+  "anon"
+)
+assert_thread_info(threads[named],
+  {name = "some-name", status = "suspended", recvt = 0, sendt = 0},
+  "named"
+)
+assert_thread_info(threads[capture],
+  {name = "capture-thread", status = "running", recvt = 0, sendt = 0},
+  "capture"
+)

--- a/test/thread-metadata/sockets.lua
+++ b/test/thread-metadata/sockets.lua
@@ -1,0 +1,84 @@
+local cosock = require "cosock"
+local server_th_name = "server"
+local client_th_name = "client"
+local server = cosock.socket.tcp()
+assert(server:bind("0.0.0.0", 0))
+assert(server:listen())
+local _, port = assert(server:getsockname())
+local ass_num = 0
+local function assert_state(info, assertions)
+  ass_num = ass_num + 1
+  for _, th in pairs(info) do
+    local assertion = assertions[th.name]
+    assert(assertion, string.format("%s Unexpected thread name: %s", ass_num, th.name or "nil"))
+    assert(th.sendt == assertion.sendt, string.format("%s Unexpected sendt for %s found %s expected %s", ass_num, th.name or "nil", th.sendt or "nil", assertion.sendt or "nil"))
+    assert(th.recvt == assertion.recvt, string.format("%s Unexpected recvt for %s found %s expected %s", ass_num, th.name or "nil", th.recvt or "nil", assertion.recvt or "nil"))
+  end
+end
+local assertions = {
+  {
+    [server_th_name] = {
+      sendt = 0,
+      recvt = 1,
+      status = "running"
+    },
+    [client_th_name] = {
+      sendt = 1,
+      recvt = 0,
+      status = "suspended"
+    }
+  },
+  {
+    [server_th_name] = {
+      sendt = 0,
+      recvt = 0,
+      status = "running"
+    },
+    [client_th_name] = {
+      sendt = 0,
+      recvt = 1,
+      status = "suspended"
+    }
+  },
+  {
+    [server_th_name] = {
+      sendt = 0,
+      recvt = 1,
+      status = "running"
+    },
+    [client_th_name] = {
+      sendt = 0,
+      recvt = 0,
+      status = "suspended"
+    }
+  },
+}
+
+cosock.spawn(function()
+  local client = server:accept()
+  assert_state(
+    cosock.get_thread_metadata(),
+    table.remove(assertions, 1)
+  )
+  cosock.socket.sleep(0)
+  assert_state(
+    cosock.get_thread_metadata(),
+    table.remove(assertions, 1)
+  )
+  client:send("bytes\n")
+  client:receive()
+end, server_th_name)
+
+cosock.spawn(function()
+  local client = cosock.socket.tcp()
+  client:connect("0.0.0.0", port)
+  client:receive()
+  cosock.socket.sleep(0)
+  assert_state(
+    cosock.get_thread_metadata(),
+    table.remove(assertions, 1)
+  )
+  client:send("bytes\n")
+end, client_th_name)
+
+cosock.run()


### PR DESCRIPTION
This PR adds 2 new things to the cosock library, first is that it starts tracking the timestamp each thread was last woken. Secondly, it adds a new public function `get_thread_metadata` that will return a list of "thread metadata" for all cosock controlled threads.

This will allow consumers to gain some level of visibility into cosock's internal state programmatically w/o exposing control of the cosock owned threads. 