### PR TITLE
Move error handling from  to  transform

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,8 @@ jobs:
         run: timeout 5 lua test/ssl/client-multi.lua
       - name: ssl client-timeout
         run: timeout 5 lua test/ssl/client-timeout.lua
+      - name: ssl client-server-large-payload
+        run: timeout 5 lua test/ssl/client-server-large-payload.lua
       - name: http http
         run: |
           $GITHUB_WORKSPACE/bin/cosock-test-server 8080 &

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,22 @@ jobs:
         run: luarocks install luasocket
       - name: install luasec
         run: luarocks install luasec
+      - name: generate self signed cert
+        run: |
+          openssl req \
+            -newkey rsa:2048 \
+            -x509 \
+            -sha256 \
+            -days 10000 \
+            -nodes \
+            -out cert.pem \
+            -keyout key.pem \
+            -subj "/C=US/ST=MN/L=Minneapolis/O=cosock/CN=cosock/"
+      - name: download server for http tests
+        run: |
+          export COSOCK_TEST_SERVER_INSTALL_DIR="${GITHUB_WORKSPACE}"
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/cosock/test-http-server/releases/download/v0.1.6/cosock-test-server-installer.sh | sh
+          
       - name: try-protect
         run: timeout 5 lua test/error-handling/try-protect.lua
       - name: spawn-child-and-die
@@ -59,11 +75,26 @@ jobs:
       - name: ssl client-timeout
         run: timeout 5 lua test/ssl/client-timeout.lua
       - name: http http
-        run: timeout 5 lua test/http/http.lua
+        run: |
+          $GITHUB_WORKSPACE/bin/cosock-test-server 8080 &
+          SERVER_PID=$!
+          # ensure the port is bound before the test starts
+          sleep 1
+          timeout 5 lua test/http/http.lua 8080
       - name: http https via ssl
-        run: timeout 5 lua test/http/https-via-ssl.lua
+        run: |
+          $GITHUB_WORKSPACE/bin/cosock-test-server 9443 . &
+          SERVER_PID=$!
+          # ensure the port is bound before the test starts
+          sleep 1
+          timeout 5 lua test/http/https-via-ssl.lua 9443
       - name: http https via http
-        run: timeout 5 lua test/http/https-via-http.lua
+        run: |
+          $GITHUB_WORKSPACE/bin/cosock-test-server 8443 . &
+          SERVER_PID=$!
+          # ensure the port is bound before the test starts
+          sleep 1
+          timeout 5 lua test/http/https-via-http.lua 8443
       - name: asyncify-works
         run: timeout 5 lua test/asyncify/asyncify-works.lua
       - name: thread-metadata sleeping

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,7 @@ jobs:
       - name: download server for http tests
         run: |
           export COSOCK_TEST_SERVER_INSTALL_DIR="${GITHUB_WORKSPACE}"
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/cosock/test-http-server/releases/download/v0.1.6/cosock-test-server-installer.sh | sh
-          
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/cosock/test-http-server/releases/download/v0.1.7/cosock-test-server-installer.sh | sh
       - name: try-protect
         run: timeout 5 lua test/error-handling/try-protect.lua
       - name: spawn-child-and-die

--- a/cosock/socket/tcp.lua
+++ b/cosock/socket/tcp.lua
@@ -92,22 +92,22 @@ m.receive = passthrough("receive", function()
         return pattern
       end
     end,
-    -- transform output after final success or (non-block) error
-    output = function(recv, err, partial)
-      assert(not (recv and partial), "socket recieve returned both data and partial data")
-
+    error = function(_sock, err, partial)
+      new_part(partial)
+      if pattern == "*a" and err == "closed" then
+        new_part(partial)
+        return table.concat(parts)
+      end
+      return nil, err, table.concat(parts)
+    end,
+    -- transform output after final success
+    output = function(recv)
+      assert(not recv, "socket receive returned nil data")
       if #parts == 0 then
-        return recv, err, partial
+        return recv
       end
-
-      new_part(recv or partial)
-      local data = table.concat(parts)
-
-      if err then
-        return nil, err, data
-      else
-        return data
-      end
+      new_part(recv)
+      return table.concat(parts)
     end,
   }
 end)

--- a/cosock/socket/tcp.lua
+++ b/cosock/socket/tcp.lua
@@ -22,6 +22,67 @@ setmetatable(m, {__call = function()
   return setmetatable({inner_sock = inner_sock, class = "tcp{master}"}, { __index = m})
 end})
 
+--- Build the receive transformer for the TCP sockets so it can be shared between this
+--- module and the `ssl` module
+---@param error_transformer any
+function m.__build_tcp_receive_transform(error_transformer)
+  return function()
+    error_transformer = error_transformer or function(err) return err end
+    local pattern
+    -- save partial results on timeout
+    local parts = {}
+    local bytes_remaining
+    local function new_part(part)
+      if type(part) == "string" and #part > 0 then
+        table.insert(parts, part)
+        if bytes_remaining then
+          bytes_remaining = bytes_remaining - #part
+        end
+      end
+    end
+    return {
+      -- transform input parameters
+      input = function(ipattern, iprefix)
+        assert(#parts == 0, "input transformer called more than once")
+        -- save these for later
+        pattern = ipattern
+        if type(pattern) == "number" then bytes_remaining = pattern end
+        new_part(iprefix)
+
+        return pattern
+      end,
+      -- receives results of luasocket call when we need to block, provides parameters to pass when next ready
+      blocked = function(_, _, partial)
+        new_part(partial)
+        if bytes_remaining then
+          assert(bytes_remaining > 0, "somehow about to block despite being done")
+          return bytes_remaining
+        else
+          return pattern
+        end
+      end,
+      error = function(_sock, err, partial)
+        err = error_transformer(err)
+        new_part(partial)
+        if pattern == "*a" and err == "closed" then
+          new_part(partial)
+          return table.concat(parts)
+        end
+        return nil, err, table.concat(parts)
+      end,
+      -- transform output after final success
+      output = function(recv)
+        assert(recv, "socket receive returned nil data")
+        if #parts == 0 then
+          return recv
+        end
+        new_part(recv)
+        return table.concat(parts)
+      end,
+    }
+  end
+end
+
 local passthrough = internals.passthroughbuilder(recvmethods, sendmethods)
 
 m.accept = passthrough("accept", {
@@ -58,59 +119,7 @@ m.getstats = passthrough("getstats")
 
 m.listen = passthrough("listen")
 
-m.receive = passthrough("receive", function()
-  local pattern
-  -- save partial resuts on timeout
-  local parts = {}
-  local bytes_remaining
-  local function new_part(part)
-    if type(part) == "string" and #part > 0 then
-      table.insert(parts, part)
-      if bytes_remaining then
-        bytes_remaining = bytes_remaining - #part
-      end
-    end
-  end
-  return {
-    -- transform input parameters
-    input = function(ipattern, iprefix)
-      assert(#parts == 0, "input transformer called more than once")
-      -- save these for later
-      pattern = ipattern
-      if type(pattern) == "number" then bytes_remaining = pattern end
-      new_part(iprefix)
-
-      return pattern
-    end,
-    -- receives results of luasocket call when we need to block, provides parameters to pass when next ready
-    blocked = function(_, _, partial)
-      new_part(partial)
-      if bytes_remaining then
-        assert(bytes_remaining > 0, "somehow about to block despite being done")
-        return bytes_remaining
-      else
-        return pattern
-      end
-    end,
-    error = function(_sock, err, partial)
-      new_part(partial)
-      if pattern == "*a" and err == "closed" then
-        new_part(partial)
-        return table.concat(parts)
-      end
-      return nil, err, table.concat(parts)
-    end,
-    -- transform output after final success
-    output = function(recv)
-      assert(not recv, "socket receive returned nil data")
-      if #parts == 0 then
-        return recv
-      end
-      new_part(recv)
-      return table.concat(parts)
-    end,
-  }
-end)
+m.receive = passthrough("receive", m.__build_tcp_receive_transform())
 
 m.send = passthrough("send")
 
@@ -125,6 +134,7 @@ function m:settimeout(timeout)
 
   return 1.0
 end
+
 
 internals.setuprealsocketwaker(m)
 

--- a/cosock/ssl.lua
+++ b/cosock/ssl.lua
@@ -48,21 +48,24 @@ m.loadcertificate = passthrough("loadcertificate")
 m.newcontext = passthrough("newcontext")
 
 m.receive = passthrough("receive", {
-  output = function(bytes, err, ...)
+  output = function(bytes)
+    return bytes
+  end,
+  error = function(_sock, err, ...)
     if err == "timeout" then
       err = "wantread"
     end
-    return bytes, err, ...
-  end
+    return nil, err, ...
+  end,
 })
 
 m.send = passthrough("send", {
-  output = function(success, err, ...)
+  error = function(_sock, err, ...)
     if err == "timeout" then
       err = "wantwrite"
     end
-    return success, err, ...
-  end
+    return nil, err, ...
+  end,
 })
 
 m.setdane = passthrough("setdane")

--- a/test/http/http.lua
+++ b/test/http/http.lua
@@ -2,8 +2,10 @@
 if _VERSION == "Lua 5.1" then os.exit(0) end
 local cosock = require "cosock"
 local perform_test = require "test.http.perform_test"
+local port = tonumber(table.pack(...)[1] or "8080")
 
-perform_test("http", "http", cosock.asyncify("socket.http").request)
+perform_test("http", "http", cosock.asyncify("socket.http").request, port)
+
 cosock.run()
 
 print("--------------- SUCCESS ----------------")

--- a/test/http/https-via-http.lua
+++ b/test/http/https-via-http.lua
@@ -3,7 +3,10 @@ if _VERSION == "Lua 5.1" then os.exit(0) end
 local cosock = require "cosock"
 local perform_test = require "test.http.perform_test"
 
-perform_test("https-via-ssl", "https", cosock.asyncify("socket.http").request)
+local port = tonumber(table.pack(...)[1] or "8080")
+
+perform_test("https-via-ssl", "https", cosock.asyncify("socket.http").request, port)
+
 cosock.run()
 
 print("--------------- SUCCESS ----------------")

--- a/test/http/https-via-ssl.lua
+++ b/test/http/https-via-ssl.lua
@@ -2,7 +2,7 @@
 if _VERSION == "Lua 5.1" then os.exit(0) end
 local cosock = require "cosock"
 local perform_test = require "test.http.perform_test"
-
-perform_test("https-via-ssl", "https", cosock.asyncify("ssl.https").request)
+local port = tonumber(table.pack(...)[1] or "8080")
+perform_test("https-via-ssl", "https", cosock.asyncify("ssl.https").request, port)
 
 print("--------------- SUCCESS ----------------")

--- a/test/http/perform_test.lua
+++ b/test/http/perform_test.lua
@@ -1,13 +1,15 @@
 local cosock = require "cosock"
 local socket = require "cosock.socket"
 
-local function slow_request(id, scheme, request, requests_started, requests_finished)
+local function slow_request(id, scheme, request, requests_started, requests_finished, port)
   return function()
     print("id", id)
     table.insert(requests_started, tostring(id))
 
     local starttime = socket.gettime()
-    local body, status = request(string.format("%s://bin.azdle.net/delay/3", scheme))
+    local url = string.format("%s://127.0.0.1:%s/delay/3", scheme, port)
+    print("requesting from", url)
+    local body, status = request(url)
     local endtime = socket.gettime()
 
     print(string.format("request took %s seconds", endtime - starttime))
@@ -21,8 +23,8 @@ local function slow_request(id, scheme, request, requests_started, requests_fini
   end
 end
 
-return function (name, scheme, request)
-  print("start")
+return function (name, scheme, request, port)
+  print(string.format("start->%s", name), port)
   local requests_started = {}
   local requests_finished = {}
   -- check that after 1 second that 3 requests have started, but that 0 have finished
@@ -35,9 +37,9 @@ return function (name, scheme, request)
     assert(#requests_finished == 0, name.." some requests already finished")
   end,
   "checker")
-  cosock.spawn(slow_request(1, scheme, request, requests_started, requests_finished), name.."-slow1")
-  cosock.spawn(slow_request(2, scheme, request, requests_started, requests_finished), name.."-slow2")
-  cosock.spawn(slow_request(3, scheme, request, requests_started, requests_finished), name.."-slow3")
+  cosock.spawn(slow_request(1, scheme, request, requests_started, requests_finished, port), name.."-slow1")
+  cosock.spawn(slow_request(2, scheme, request, requests_started, requests_finished, port), name.."-slow2")
+  cosock.spawn(slow_request(3, scheme, request, requests_started, requests_finished, port), name.."-slow3")
   cosock.run()
   print(name.." requests finished", #requests_finished)
   assert(#requests_finished == 3, name..": not all requests (or too many) finished")

--- a/test/ssl/client-server-large-payload.lua
+++ b/test/ssl/client-server-large-payload.lua
@@ -1,0 +1,117 @@
+local cosock = require 'cosock'
+local socket = cosock.socket
+local ssl = cosock.ssl
+
+local size = 65535
+local chunks = { 1, 4096, 8191, 8192, 8193, 16384, 65535 }
+
+local sock = assert(socket.tcp());
+sock:bind('0.0.0.0', 0)
+sock:setoption('reuseaddr', true)
+sock:listen(1)
+
+print('listening on:', sock:getsockname())
+local addr, port = sock:getsockname()
+
+local running = #chunks
+local killer, killed = cosock.channel.new()
+
+cosock.spawn(function()
+  while true do
+    local recvr, _, err = socket.select({sock, killed}, {})
+
+    if err or recvr[1] == killed then
+      break
+    end
+    local config = {
+      mode = "server",
+      protocol = "any",
+      cafile = "./test/ssl/certs/root.crt.pem",
+      certificate = "./test/ssl/certs/leafD_intermediate2_chain.crt.pem",
+      key = "./test/ssl/certs/private/leafD.key.pem",
+      password = "cosock",
+      verify = {"peer", "fail_if_no_peer_cert"},
+      options = {"all", "no_sslv3"}
+    }
+    -- accept a new client
+    local client = assert(sock:accept())
+    print("server ssl wrap accepted socket")
+    client = assert(ssl.wrap(client, config))
+    assert(client:dohandshake())
+    -- spawn handler for new client
+    cosock.spawn(function()
+      -- receive a request for a certain number of bytes
+      local size = tonumber(assert(client:receive()))
+      print(sock_num, 'received request for:', size)
+      while sent < size do
+        local send_size = chunk_size
+        if sent + chunk_size > size then
+          send_size = size - sent
+        end
+        local ct = assert(client:send(string.rep('*', send_size)))
+        -- print('sent', ct)
+        sent = sent + ct
+        -- yield
+        cosock.socket.sleep(0.25)
+      end
+      -- echo bytes back to client
+      local ct = assert(client:send(string.rep('*', size, '')))
+      print('sent', ct)
+      assert(ct == size, "send incomplete")
+
+      -- clean up socket
+      client:close()
+    end)
+  end
+  sock:close()
+end, 'blob server')
+
+for _, chunk in ipairs(chunks) do
+  cosock.spawn(function()
+    local client = assert(socket.tcp())
+    -- connect to the server
+    assert(client:connect(addr, port))
+    local config = {
+      mode = "client",
+      protocol = "any",
+      cafile = "./test/ssl/certs/root.crt.pem",
+      certificate = "./test/ssl/certs/leafC_intermediate2_chain.crt.pem",
+      key = "./test/ssl/certs/private/leafC.key.pem",
+      password = "cosock",
+      verify = {"peer", "fail_if_no_peer_cert"},
+      options = {"all", "no_sslv3"}
+    }
+    client = assert(ssl.wrap(client, config))
+    assert(client:dohandshake())
+    -- send a large number of bytes
+    assert(client:send(tostring(size).."\n"))
+    local s = ''
+    local byte_ct = chunk
+    -- receive those bytes in chunks
+    while #s < size do
+      -- NOTE: This loop must be silent or GH actions dies from too much logging
+      --       uncomment locally for debugging
+
+      -- if the last chunk would block forever because the chunk size isn't
+      -- equal, reduce the byte_ct to the appropriate value
+      if size - #s < byte_ct then
+        --print(string.format('%s - %s = %s', size, #s, size - #s))
+        byte_ct = size - #s
+      end
+      --print('receiving', byte_ct)
+      s = s .. assert(client:receive(byte_ct))
+      -- print('recvd', #s, 'so far')
+    end
+    assert(#s == size)
+    client:close()
+
+    -- last one alive, lock the door (aka, kill the server)
+    running = running - 1
+    if running <= 0 then
+      killer:send()
+    end
+  end, 'blob client')
+end
+
+cosock.run()
+print('Exited successfully')


### PR DESCRIPTION
This PR move the error handling from the exiting `output` transform function into a new `error` transform. 

~The primary driver here is that MacOS will return `nil, "timeout"` on calls to `connect` but when write readiness is reached to complete the connection calling `connect` again will return `nil, "already connected"`. For good measure I've added this same error handling to `accept` though it may be removable.~

After additional investigation the `nil, "already connected"` error on macos is a fatal error. A different mechanism is going to need to be introduced to handle functions that shouldn't be considered "successful" after the call to `coroutine.yield` resolves.

I believe this closes #36