### PR TITLE
Chore/more functions

### DIFF
--- a/cosock.lua
+++ b/cosock.lua
@@ -2,6 +2,7 @@ local socket = require "cosock.socket"
 local nativesocket = require "socket"
 local channel = require "cosock.channel"
 local ssl = require "cosock.ssl"
+local timers = require "cosock.timers"
 
 local weaktable = { __mode = "kv" } -- mark table as having weak refs to keys and values
 local weakkeys = { __mode = "k" } -- mark table as having weak refs to keys
@@ -79,67 +80,6 @@ m._VERSION = "0.2.0"
 m.socket = socket
 m.channel = channel
 m.ssl = ssl
-
-local timers = {}
-do
-  local timeouts = {}
-  local refs = {}
-  -- takes a relative timeout, a callback that is called with no params,
-  -- and an optional reference object for cancellation
-  timers.set = function(timeout, callback, ref)
-    print("timer set: %s,%s", timeout, ref)
-    local now = nativesocket.gettime()
-    local timeoutat = timeout + now
-    print(timeoutat, timeout, now)
-    local timeoutinfo = {timeoutat = timeoutat, callback = callback, ref = ref}
-    table.insert(timeouts, timeoutinfo)
-    if ref then refs[ref] = timeoutinfo end
-  end
-
-  timers.cancel = function(ref)
-    local timeoutinfo = refs[ref]
-    if timeoutinfo then
-      -- mark as canceled, actual object will fall out at originally scheduled time
-      timeoutinfo.callback = nil
-      timeoutinfo.ref = nil
-    end
-    refs[ref] = nil
-  end
-
-  -- run expired timers, returns time to next timeout expiration
-  timers.run = function()
-    -- this seems exceptionally inefficient, but it works
-    -- TODO: I dunno, maybe use a timerwheel, after benchmarks
-    table.sort(
-      timeouts,
-      function(a,b)
-        -- bubble nil timeouts to the top to be dropped
-        return
-          not a.timeoutat or
-          (a.timeoutat and b.timeoutat and a.timeoutat < b.timeoutat)
-      end
-    )
-
-    local now = nativesocket.gettime()
-
-    -- process timeout callback and remove
-    while timeouts[1] and (timeouts[1].timeoutat == nil or timeouts[1].timeoutat < now) do
-      local timeoutinfo = table.remove(timeouts, 1)
-      if timeoutinfo.callback then timeoutinfo.callback() end
-      if timeoutinfo.ref then refs[timeoutinfo.ref] = nil end
-    end
-
-    local timeoutat = (timeouts[1] or {}).timeoutat
-    print("timeout time", timeoutat)
-    if timeoutat then
-      local timeout = timeoutat - now
-      print("earliest timeout", timeout)
-      return timeout
-    else
-      return nil
-    end
-  end
-end
 
 -- asyncify
 do

--- a/cosock.lua
+++ b/cosock.lua
@@ -81,72 +81,7 @@ m.socket = socket
 m.channel = channel
 m.ssl = ssl
 
--- asyncify
-do
-  local realrequire = require
-  local asyncify_loaded = {}
-  local function wrappedrequire(name)
-    --[[ Our API is incomplete, just choose a few specific modules for now
-    if string.sub(name, 1, 6) == "socket" then
-      name = "cosock."..name
-    end
-    ]]
-    local subbed
-    if name == "socket" then
-      subbed = "cosock.socket"
-    elseif name == "ssl" then
-      subbed = "cosock.ssl"
-    end
-    return subbed and realrequire(subbed) or m.asyncify(name)
-  end
-
-  local fakeenv = {
-    require = wrappedrequire
-  }
-  setmetatable(fakeenv, {__index = _ENV })
-
-  function m.asyncify(name)
-    local err
-    if name == "socket" then name = "cosock.socket" end
-    if name == "ssl" then name = "cosock.ssl" end
-    
-    if asyncify_loaded[name] then
-      return asyncify_loaded[name]
-    end
-    for _,searcher in ipairs(package.searchers) do
-      local loader, loc = searcher(name)
-      if type(loader) == "function" then
-        -- figure out which upvalue is env
-        local upvalueidx = 0
-        repeat
-          upvalueidx = upvalueidx + 1
-          local uvname, _ = debug.getupvalue(loader, upvalueidx)
-          if not uvname then upvalueidx = nil; break end
-        until uvname == "_ENV"
-
-        -- set loader env to fake env to override calls to `require`
-        if upvalueidx then
-          debug.setupvalue(loader, upvalueidx, fakeenv)
-        end
-
-        -- load module with loader
-        local module = loader(name, loc)
-        asyncify_loaded[name] = module
-        return module
-      -- If the last searcher returns nil we need to check the
-      -- package.loaded or we may miss some std lib packages
-      elseif loader == nil and package.loaded[name] then
-        asyncify_loaded[name] = package.loaded[name]
-        return package.loaded[name]
-      else
-        -- non-function values mean error, keep last non-nil value
-        err = loader or err
-      end
-    end
-
-    return err
-  end
-end
+m.asyncify = require "cosock.asyncify"
 
 function m.spawn(fn, name)
   local thread = coroutine.create(fn)

--- a/cosock/asyncify.lua
+++ b/cosock/asyncify.lua
@@ -1,0 +1,67 @@
+local m = {}
+
+local realrequire = require
+local asyncify_loaded = {}
+local function wrappedrequire(name)
+  --[[ Our API is incomplete, just choose a few specific modules for now
+  if string.sub(name, 1, 6) == "socket" then
+    name = "cosock."..name
+  end
+  ]]
+  local subbed
+  if name == "socket" then
+    subbed = "cosock.socket"
+  elseif name == "ssl" then
+    subbed = "cosock.ssl"
+  end
+  return subbed and realrequire(subbed) or m.asyncify(name)
+end
+
+local fakeenv = {
+  require = wrappedrequire
+}
+setmetatable(fakeenv, {__index = _ENV })
+
+function m.asyncify(name)
+  local err
+  if name == "socket" then name = "cosock.socket" end
+  if name == "ssl" then name = "cosock.ssl" end
+  
+  if asyncify_loaded[name] then
+    return asyncify_loaded[name]
+  end
+  for _,searcher in ipairs(package.searchers) do
+    local loader, loc = searcher(name)
+    if type(loader) == "function" then
+      -- figure out which upvalue is env
+      local upvalueidx = 0
+      repeat
+        upvalueidx = upvalueidx + 1
+        local uvname, _ = debug.getupvalue(loader, upvalueidx)
+        if not uvname then upvalueidx = nil; break end
+      until uvname == "_ENV"
+
+      -- set loader env to fake env to override calls to `require`
+      if upvalueidx then
+        debug.setupvalue(loader, upvalueidx, fakeenv)
+      end
+
+      -- load module with loader
+      local module = loader(name, loc)
+      asyncify_loaded[name] = module
+      return module
+    -- If the last searcher returns nil we need to check the
+    -- package.loaded or we may miss some std lib packages
+    elseif loader == nil and package.loaded[name] then
+      asyncify_loaded[name] = package.loaded[name]
+      return package.loaded[name]
+    else
+      -- non-function values mean error, keep last non-nil value
+      err = loader or err
+    end
+  end
+
+  return err
+end
+
+return m.asyncify

--- a/cosock/timers.lua
+++ b/cosock/timers.lua
@@ -1,0 +1,63 @@
+local nativesocket = require "socket"
+local print = function(...) end
+local timers = {}
+
+local timeouts = {}
+local refs = {}
+-- takes a relative timeout, a callback that is called with no params,
+-- and an optional reference object for cancellation
+timers.set = function(timeout, callback, ref)
+  print("timer set: %s,%s", timeout, ref)
+  local now = nativesocket.gettime()
+  local timeoutat = timeout + now
+  print(timeoutat, timeout, now)
+  local timeoutinfo = {timeoutat = timeoutat, callback = callback, ref = ref}
+  table.insert(timeouts, timeoutinfo)
+  if ref then refs[ref] = timeoutinfo end
+end
+
+timers.cancel = function(ref)
+  local timeoutinfo = refs[ref]
+  if timeoutinfo then
+    -- mark as canceled, actual object will fall out at originally scheduled time
+    timeoutinfo.callback = nil
+    timeoutinfo.ref = nil
+  end
+  refs[ref] = nil
+end
+
+-- run expired timers, returns time to next timeout expiration
+timers.run = function()
+  -- this seems exceptionally inefficient, but it works
+  -- TODO: I dunno, maybe use a timerwheel, after benchmarks
+  table.sort(
+    timeouts,
+    function(a,b)
+      -- bubble nil timeouts to the top to be dropped
+      return
+        not a.timeoutat or
+        (a.timeoutat and b.timeoutat and a.timeoutat < b.timeoutat)
+    end
+  )
+
+  local now = nativesocket.gettime()
+
+  -- process timeout callback and remove
+  while timeouts[1] and (timeouts[1].timeoutat == nil or timeouts[1].timeoutat < now) do
+    local timeoutinfo = table.remove(timeouts, 1)
+    if timeoutinfo.callback then timeoutinfo.callback() end
+    if timeoutinfo.ref then refs[timeoutinfo.ref] = nil end
+  end
+
+  local timeoutat = (timeouts[1] or {}).timeoutat
+  print("timeout time", timeoutat)
+  if timeoutat then
+    local timeout = timeoutat - now
+    print("earliest timeout", timeout)
+    return timeout
+  else
+    return nil
+  end
+end
+
+return timers


### PR DESCRIPTION
This PR represents a large but immaterial refactor of the `cosock.lua` file to break things up a bit. I've tried to structure this commit-by-commit to make reviewing easier but I do realize it appears to be quite a bit of code.

I have gone to great lengths to avoid making any material changes to the logic of any specific part, I have simply cut and pasted the logical boundaries into their own function/modules.

The first 5 commits take parts of `m.run` in `cosock.lua` and move them into local functions above the definition of `m.run`. The next 2 commits move the `timers` and `asyncify` `do` blocks and moves them to their own modules in the `/cosock` directory. Lastly I went back and added some doc comments to the new helper functions.