### PR TITLE
add thread handle API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,12 @@ jobs:
         run: timeout 5 lua test/error-handling/try-protect.lua
       - name: spawn-child-and-die
         run: timeout 5 lua test/threads/spawn-child-and-die.lua
+      - name: handle-aliveness-works
+        run: timeout 5 lua test/threads/handle-aliveness-works.lua
+      - name: handles-can-cancel
+        run: timeout 5 lua test/threads/handles-can-cancel.lua
+      - name: handles-cannot-cancel-self
+        run: timeout 5 lua test/threads/handles-cannot-cancel-self.lua
       - name: basic channel
         run: timeout 5 lua test/channel/basic.lua
       - name: select channel

--- a/cosock.lua
+++ b/cosock.lua
@@ -99,6 +99,20 @@ end
 
 local thread_handle = {}
 thread_handle.__index = thread_handle
+thread_handle.__tostring = function(self)
+  if type(self.name) == "string" then
+    return self.name
+  end
+  -- name is populated but not a string
+  if self.name then
+    return tostring(self.name)
+  end
+  local thread = threadhandles[self]
+  if not thread then
+    return "dead-thread"
+  end
+  return tostring(thread)
+end
 
 function thread_handle:cancel()
   local thread = threadhandles[self]

--- a/cosock.lua
+++ b/cosock.lua
@@ -9,6 +9,7 @@ local weakkeys = { __mode = "k" } -- mark table as having weak refs to keys
 
 local threads = {} --TODO: use set instead of list
 local threadnames = setmetatable({}, weakkeys)
+local threadhandles = setmetatable({}, weaktable)
 local threadswaitingfor = {} -- what each thread is waiting for
 local readythreads = {} -- like wakethreads, but for next loop (can be modified while looping wakethreads)
 local socketwrappermap = setmetatable({}, weaktable) -- from native socket to async socket
@@ -83,14 +84,6 @@ m.ssl = ssl
 
 m.asyncify = require "cosock.asyncify"
 
-function m.spawn(fn, name)
-  local thread = coroutine.create(fn)
-  print("socket spawn", name or thread)
-  threadnames[thread] = name
-  threads[thread] = thread
-  readythreads[thread] = {}
-end
-
 local function wake_thread(wakelist, thread, kind, skt)
   print("wake thread", thread, kind, skt)
   wakelist[thread] = wakelist[thread] or {}
@@ -102,6 +95,47 @@ local function wake_thread_err(wakelist, thread, err)
   print("wake thread err", thread, err)
   wakelist[thread] = wakelist[thread] or {}
   wakelist[thread].err = err
+end
+
+function m.spawn(fn, name)
+  local thread = coroutine.create(fn)
+  print("socket spawn", name or thread)
+  threadnames[thread] = name
+  local handle = {
+    name = name or tostring(thread)
+  }
+  threadhandles[handle] = thread
+  function handle:cancel()
+    local thread = assert(threadhandles[handle], "thread handle dropped!")
+    if coroutine.status(thread) == "running" then
+      error("Attempt to cancel a spawned task from itself")
+    end
+    -- lua 5.4 only
+    if type(coroutine.close) == "function" then
+      coroutine.close(thread)
+      return
+    end
+    -- fallback for pre-5.4, remove all references to the thread, it will no longer
+    -- be polled in `cosock.run`
+    threadhandles[handle] = nil
+    readythreads[thread] = nil
+    threads[thread] = nil
+    threadnames[thread] = nil
+    threadswaitingfor[thread] = nil
+    timers.cancel(thread)
+    last_wakes[thread] = nil
+  end
+  function handle:is_alive()
+    -- was removed in `cancel` above _or_ `cosock.run`
+    local thread = threadhandles[handle]
+    if not thread then
+      return false
+    end
+    return coroutine.status(thread) ~= "dead"
+  end
+  threads[thread] = thread
+  readythreads[thread] = {}
+  return handle
 end
 
 --- Drain the current state of `readythreads` into a list table to resume those threads

--- a/test/threads/handle-aliveness-works.lua
+++ b/test/threads/handle-aliveness-works.lua
@@ -1,0 +1,17 @@
+local cosock = require "cosock"
+
+local tx, rx = cosock.channel.new()
+
+local handle = cosock.spawn(function()
+  rx:receive()
+end)
+
+cosock.spawn(function()
+  assert(handle:is_alive())
+  tx:send({})
+  -- yield to allow the `handle` task to complete
+  cosock.socket.sleep(0)
+  assert(not handle:is_alive())
+end)
+
+cosock.run()

--- a/test/threads/handle-to-string.lua
+++ b/test/threads/handle-to-string.lua
@@ -1,0 +1,34 @@
+local cosock = require "cosock"
+
+local named_tx, named_rx = cosock.channel.new()
+local unnamed_tx, unnamed_rx = cosock.channel.new()
+
+local nameless = cosock.spawn(function()
+  cosock.socket.sleep(65535)
+end)
+
+local named = cosock.spawn(function()
+  cosock.socket.sleep(65535)
+end, "named")
+
+local number_name = cosock.spawn(function()
+  cosock.socket.sleep(65535)
+end, 1)
+local t = {}
+local table_name = cosock.spawn(function()
+  cosock.socket.sleep(65535)
+end, t)
+
+cosock.spawn(function()
+  assert(string.sub(tostring(nameless), 1, 6) == "thread", string.format("expected `thread <pointer>` found `%s`", nameless))
+  nameless:cancel()
+  assert(tostring(nameless) == "dead-thread")
+  assert(tostring(named) == "named", string.format("expected `named` found `%s`", named))
+  named:cancel()  
+  assert(tostring(number_name) == "1", string.format("expected `1` found `%s`", number_name))
+  number_name:cancel()
+  assert(tostring(table_name) == tostring(t), string.format("expected `%s` found `%s`", t, table_name))
+  table_name:cancel()
+end)
+
+cosock.run()

--- a/test/threads/handles-can-cancel.lua
+++ b/test/threads/handles-can-cancel.lua
@@ -1,0 +1,41 @@
+local cosock = require "cosock"
+
+local control_tx, control_rx = cosock.channel.new()
+
+local sleep_handle = cosock.spawn(function()
+  control_tx:send({})
+  cosock.socket.sleep(math.maxinteger)
+end, "sleep")
+
+local _, handle_rx = cosock.channel.new()
+local rx_handle = cosock.spawn(function()
+  control_tx:send({})
+  handle_rx:receive()
+end, "rx")
+
+local socket_handle = cosock.spawn(function()
+  control_tx:send({})
+  local udp = assert(cosock.socket.udp())
+  udp:setsockname("*", 0)
+  assert(udp:receivefrom())
+end, "socket")
+
+local handles = {sleep_handle, rx_handle, socket_handle}
+
+local killer = cosock.spawn(function()
+  -- wait for all to be yielding
+  for i=1, #handles do
+    assert(control_rx:receive())
+  end
+  for _,handle in ipairs(handles) do
+    print("checking", handle.name)
+    assert(handle:is_alive(), string.format("expected %q to be alive", handle.name))
+    print("canceling", handle.name)
+    handle:cancel()
+    print("confirming", handle.name)
+    assert(not handle:is_alive(), string.format("expected %q to be dead", handle.name))
+    print("successfully canceled", handle.name)
+  end
+end)
+
+cosock.run()

--- a/test/threads/handles-cannot-cancel-self.lua
+++ b/test/threads/handles-cannot-cancel-self.lua
@@ -1,0 +1,13 @@
+local cosock = require "cosock"
+
+local handle
+local function task_fn()
+  assert(handle:is_alive())
+  local s, err = pcall(handle.cancel, handle)
+  assert(not s, "Expected cancel in own task to fail found " .. tostring(s))
+  assert(err)
+end
+
+handle = cosock.spawn(task_fn)
+
+cosock.run()


### PR DESCRIPTION
This PR adds a new thread handle return value from `cosock.spawn` to allow for more robust coroutine interactions. For example with this API it would now be possible to implement proper debouncing.

```lua
local cosock = require "cosock"

local function emit_log(...)
  print(os.time(), ...)
end

local function actually_do_work()
  -- to something maybe expensive here...
  emit_log("actually working!")
end

local handle
local function do_work_debounced()
  if handle and handle:is_alive() then
    emit_log("debounced")
    return
  end
  handle = cosock.spawn(function()
    cosock.socket.sleep(1)
    actually_do_work()
    handle = nil
  end, "debounce-task")
end

cosock.spawn(function()
  emit_log("starting")
  for i=0,10 do
    do_work_debounced()
    cosock.socket.sleep(0.5)
  end
end, "main")

cosock.run()


```

which would output something like

```console
1735334743      starting
1735334744      debounced
1735334744      actually working!
1735334745      debounced
1735334745      actually working!
1735334746      debounced
1735334746      actually working!
1735334747      debounced
1735334747      actually working!
1735334748      debounced
1735334748      actually working!
1735334749      actually working!
```