### PR TITLE
clamp native timeouts to 1 year

### DIFF
--- a/cosock.lua
+++ b/cosock.lua
@@ -296,6 +296,11 @@ local function build_select_arguments()
     timeout = 0
   end
 
+  -- clamp native timeout to 1 year, extremely large values can break `select`
+  if timeout and timeout > 31536000 then
+    timeout = 31536000
+  end
+
   return sendt, recvt, timeout
 end
 

--- a/test/workarounds/extremely-large-timeouts.lua
+++ b/test/workarounds/extremely-large-timeouts.lua
@@ -1,0 +1,13 @@
+local cosock = require "cosock"
+
+cosock.spawn(function()
+  -- create socket, will be send-ready by default
+  local s = cosock.socket.udp()
+  assert(s:setsockname("localhost", 0))
+
+  -- ensure select doesn't error with very large timeouts
+  local recvr, sendr, err = cosock.socket.select({}, {s}, math.maxinteger)
+  assert(err == nil, err)
+end, "large timeout")
+
+cosock.run()


### PR DESCRIPTION
Extremely large values for timeout can cause luasocket's select to fail. Hitting the short timeout only causes cosock's run loop to step once, it does not cause any threads to be resumed early.

fixes #45 